### PR TITLE
fix: p2p scheduler link

### DIFF
--- a/ipfs_lite/ipfs/graphsync/impl/CMakeLists.txt
+++ b/ipfs_lite/ipfs/graphsync/impl/CMakeLists.txt
@@ -24,6 +24,7 @@ target_include_directories(graphsync PRIVATE "${CMAKE_BINARY_DIR}/generated/ipfs
 target_link_libraries(graphsync
     Boost::boost
     p2p::subscription
+    p2p::p2p_scheduler
     cid
     buffer
     cbor


### PR DESCRIPTION
I believe this is your working branch, my build on linux was failing because of this link missing